### PR TITLE
Fix decode corruption issue

### DIFF
--- a/src/gallium/drivers/d3d12/d3d12_video_dec.h
+++ b/src/gallium/drivers/d3d12/d3d12_video_dec.h
@@ -99,7 +99,9 @@ struct d3d12_video_decoder
    const uint m_NodeIndex = 0u;
 
    ComPtr<ID3D12Fence> m_spFence;
+   ComPtr<ID3D12Fence> m_spFenceSync;
    uint                m_fenceValue = 1u;
+   uint                m_fenceSyncValue = 1u;
 
    ComPtr<ID3D12VideoDevice>             m_spD3D12VideoDevice;
    ComPtr<ID3D12VideoDecoder>            m_spVideoDecoder;


### PR DESCRIPTION
Certain frames will have artifacts or green image(no data) due to
data not done copying into driver.
Root cause: there is a call of buffer_subdata in d3d12_video_decoder_end_frame to
create a temp resoure, do map/umap to set bitstream data (CPU side) into this resource,
call CopyBufferRegion to copy temp resource data into real bistream buffer, Then do decode.
However, there is sync missed between CopyBufferRegion and decode.

Fix is:
1. Create a fence for sync between copy bitstream and decode workload.
2. Add fence Signal at common CmdQueue after Execute CmdList of workload:
copy bitstream from temp to bitstream buffer through CopyBufferRegion.
3. Add fence Wait at decode CmdQueue before Execute CmdList of workload decode.

Signed-off-by: Wang, Yuchen <yuchen.wang@intel.com>